### PR TITLE
Added links to slides for 2019 presenters

### DIFF
--- a/2019/index.html
+++ b/2019/index.html
@@ -189,6 +189,34 @@
               <div class="col-md-2"><time>14:00 - 14:45</time></div>
               <div class="col-md-10">
                 <h4>Short 10 minute talks. <span>Various Speakers.</span></h4>
+                <a href="https://www.youtube.com/watch?v=Kp8BHwzPcVI">
+                  <h4>Going Serverless with Firebase and Fullstack Clojurescript. <span>Théo Villard</span></h4>
+                </a>
+                <a href="theophile-villard-reclojure.pdf">slides</a>
+                <p></p>
+              </div>
+              <div class="col-md-2"><time></time></div>
+              <div class="col-md-10">
+                <a href="https://www.youtube.com/watch?v=1rZtTKR7YHY">
+                  <h4>Property based testing for Stateful apps. <span>Akshay Karle</span></h4>
+                </a>
+                <a href="akshay-karle-lightning-talk.pdf">slides</a>
+                <p></p>
+              </div>
+              <div class="col-md-2"><time></time></div>
+              <div class="col-md-10">
+                <a href="https://www.youtube.com/watch?v=OEiuD37P0dg">
+                  <h4>Twillio API with Clojure. <span>Matthew Gilliard</span></h4>
+                </a>
+                <p></p>
+              </div>
+
+              <div class="col-md-2"><time></time></div>
+              <div class="col-md-10">
+                <a href="https://www.youtube.com/watch?v=gsTWmcZ3lEM">
+                  <h4>Lost in the Streams. <span>Andrea Crotti</span></h4>
+                </a>
+                <a href=" https://github.com/FundingCircle/topology-grapher/#tutorial">repo</a>
                 <p></p>
               </div>
             </div>

--- a/2019/index.html
+++ b/2019/index.html
@@ -173,6 +173,7 @@
                 <a href="https://www.youtube.com/watch?v=zP1qStsGlFE">
                   <h4>Live Coding a Mandelbrot Renderer. <span>Peter Westmacott.</span></h4>
                 </a>
+                <a href="https://github.com/peterwestmacott/mandelbrot/blob/30960e771c451fe388eb7164d23925b23afc9d6a/src/slides.clj">code & slides</a>
                 <p>In this talk, Peter will demonstrate live coding of a fractal renderer, with the aim to show how complex beauty can emerge from simple mathematical rules and a little code.</p>
               </div>
             </div>

--- a/2019/index.html
+++ b/2019/index.html
@@ -133,6 +133,7 @@
                 <a href="https://www.youtube.com/watch?v=AkmGHhPCkgw">
                   <h4>Building stuff with Clojure and 3D Printing. <span>Clément Salaün.</span></h4>
                 </a>
+                <a href="clement-salaun-building-stuff-with-clojure.pdf">slides</a>
                 <p>How to design objects with Clojure, OpenSCAD and then 3D print them. This talk covers the motivations, basic concepts and features with a live demo.</p>
               </div>
             </div>
@@ -143,6 +144,7 @@
                 <a href="https://www.youtube.com/watch?v=iAKzNTb3Sog">
                   <h4>Clojure Art. <span>Karl Brodowsky.</span></h4>
                 </a>
+                <a href="karl-brodowsky-clojure-art.pdf">slides</a>
                 <p>Teaching or learning Clojure using images has been proven to be fun and beneficial! In this talk, learn how.</p>
               </div>
             </div>
@@ -160,6 +162,7 @@
                 <a href="https://www.youtube.com/watch?v=BZR4N5cY64U">
                   <h4>Growing Mobile Apps with ClojureScript and React Native. <span>Daniel Neal.</span></h4>
                 </a>
+                <a href="daniel-neal-reClojure-presentation-20191202.pdf">slides</a>
                 <p>Starting things is fun, but growing them can be a real challenge - and mobile apps are no different...</p>
               </div>
             </div>
@@ -195,6 +198,7 @@
                 <a href="https://www.youtube.com/watch?v=_p-6SMQTuik">
                   <h4>Unleash the power of the REPL. <span>Dana Borinski.</span></h4>
                 </a>
+                <a href="dana-borinski-repl-based-debugging.pdf">slides</a>
                 <p>Return to basics and dive into how to leverage the REPL to solve problems and debug more quickly - and with the added bonus of honing our Clojure skills!</p>
               </div>
             </div>
@@ -205,6 +209,7 @@
                 <a href="https://www.youtube.com/watch?v=W3jx3WfSvuU">
                   <h4>Generating Generators. <span>Andy Chambers.</span></h4>
                 </a>
+                <a href="andy-chambers-generating-generators.pdf">slides</a>
                 <p>Generating data for use in tests can be laborious and boring. However, using the database's information schema you can alleviate that! Discover the ways to achieve this.</p>
               </div>
             </div>

--- a/2019/index.html
+++ b/2019/index.html
@@ -228,6 +228,7 @@
                 <a href="https://www.youtube.com/watch?v=LSRQ4g5pv1o">
                   <h4>Living in a Box. Life in Containers with the JVM. <span>Matthew Gilliard.</span></h4>
                 </a>
+                <a href="matthew-gilliard-clojure-in-a-world-of-containers.pdf">slides</a>
                 <p>A focus on how containers and the JVM interact and what implications are there for Clojure Developers. Get the best results from the work gone into OpenJDK container support.</p>
               </div>
             </div>


### PR DESCRIPTION
Added links to slides for the main talks from 2019.

If the link to slides is missing, it's only because we didn't receive
them.

