### PR TITLE
Really show the active day

### DIFF
--- a/index.html
+++ b/index.html
@@ -120,10 +120,10 @@
 
         <ul class="nav nav-tabs" role="tablist">
           <li class="nav-item">
-            <a class="nav-link active" href="#day-1" role="tab" data-toggle="tab">Friday 2pm-10:30pm GMT</a>
+            <a class="nav-link" href="#day-1" role="tab" data-toggle="tab">Friday 2pm-10:30pm GMT</a>
           </li>
           <li class="nav-item">
-            <a class="nav-link" href="#day-2" role="tab" data-toggle="tab">Saturday 8:30am-5pm GMT</a>
+            <a class="nav-link active" href="#day-2" role="tab" data-toggle="tab">Saturday 8:30am-5pm GMT</a>
           </li>
         </ul>
 


### PR DESCRIPTION
Previously it would just show the Saturday, but the selected button
would still be Friday. This change fixes that.