### PR TITLE
Fix slug query

### DIFF
--- a/src/org/reclojure/db.clj
+++ b/src/org/reclojure/db.clj
@@ -697,6 +697,9 @@ Any questions? hello@xtdb.com",
   (let [times->datetimes (make-datetime-with-tz saturday)]
     (map times->datetimes (:saturday schedule-2021))))
 
+(defn get-slug [name]
+  (:slug (first (filter #(= name (:name %)) speakers-data))))
+
 (comment
   ;; Sort talks by index
   (sort-by :index (filter #(= (:type %) :Talk) (:friday schedule-2021)))

--- a/src/org/reclojure/db.clj
+++ b/src/org/reclojure/db.clj
@@ -86,7 +86,7 @@
     :picture "ethan-miller.jpg"
     :brief ""
     :description "Ethan Miller is a full-stack software engineer with interest in functional programming and Clojure in particular. For the past few years, he has tried to help build and organize the SciCloj community and contribute to the Clojure data science ecosystem."}
-   {:name "Joao Santiago"
+   {:name "João Santiago"
     :slug "joao-santiago"
     :handle ""
     :link ""
@@ -182,7 +182,7 @@
     [{:title "How to Talk with Data Scientists?"
       :description "Engineers and Data Scientists work towards the same business goals, but sometimes have different concerns to get there. In this workshop, we'll review situations showcasing what data scientists need to be successful, and by consequence how engineers can better cope with those requests. Bring your stories and your questions!",
       :libraries [],
-      :presenter "Joao Santiago",
+      :presenter "João Santiago",
       :length "90min",
       :datetimes ["2021-11-13-14:00"]
       :link "https://www.meetup.com/London-Clojurians/events/282011179/"}
@@ -484,7 +484,7 @@ Any questions? hello@xtdb.com",
      :time-end "17:10"
      :duration 25
      :title "Just-in-time features in machine learning models: why not Clojure?"
-     :speakers ["Joao Santiago"]
+     :speakers ["João Santiago"]
      :tags [:data-science]
      :abstract "It is common for real-time Machine Learning models to use transformed data, instead of raw inputs from a user or some other system. Currently, this critical step is embedded in frameworks such as sci-kit learn or tidymodels, extra code in the APIs that wrap the models or totally rewritten in another language such as Scala and served via Spark. Such practices lead to duplication of code, decrease reusability and introduce new points of friction. In this talk I want to further explore this problem so common among data science teams, and present Bulgogi, my idea for a Clojure system to fix it. Because if it's data, why not Clojure?"}
     {:index 15

--- a/src/org/reclojure/views/components/schedule.clj
+++ b/src/org/reclojure/views/components/schedule.clj
@@ -8,9 +8,6 @@
 
 ;; Utils
 
-(defn make-slug [name]
-  (-> name (str/replace #" " "-") str/lower-case))
-
 (defn time-str [datetime]
   (str/join " " [(last (re-find #"(\d+:\d+)" datetime)) "UTC"]))
 
@@ -153,7 +150,7 @@
      [:h4 title]
      [:p.name
       (->> (map (fn [speaker]
-                  [:a {:href (str "/2021/speaker/" (make-slug speaker))}
+                  [:a {:href (str "/2021/speaker/" (db/get-slug speaker))}
                    speaker])
                 speakers)
            (interleave (repeat ", "))


### PR DESCRIPTION
The cause was just a silly shameful function that tried to replicate the slug from the author name. Now we get it from the `db` for everyone so no need to remove the accents from the names anymore.