### PR TITLE
Felipe/bug fixes

### DIFF
--- a/src/org/reclojure/views/components/schedule.clj
+++ b/src/org/reclojure/views/components/schedule.clj
@@ -97,17 +97,20 @@
      :slug slug}))
 
 (defstyled pic :img
-  {:aspect-ratio "1/1"
-   :border-radius "50%" 
+  {:border-radius "50%"
    :object-fit "cover"
    :width "6rem"
+   :height "6rem"
    :align-self "start"
    :justify-self "center"
    :background-color c/white
 
    :border-right (str "0.1px solid " c/white)
    :border-bottom (str "0.1px solid " c/white)
-   :box-shadow (str "1rem 1rem 0 0 var(--accent-color)")})
+   :box-shadow (str "1rem 1rem 0 0 var(--accent-color)")}
+  [:at-supports {:aspect-ratio "1/1"}
+   {:height "unset"
+    :aspect-ratio "1/1"}])
 
 ;; FIXME: This should work with `ornament` in the above `pic`
 ;; `defstyled` but the map is being converted to a string. Possibly

--- a/src/org/reclojure/views/home.clj
+++ b/src/org/reclojure/views/home.clj
@@ -191,8 +191,10 @@
          :margin-left "1.8rem"
          :margin-top "1.8rem"
          :object-fit "cover"
-         :aspect-ratio "1/1"
-         :max-height "max(10rem, 30vh)"}
+         ;; :aspect-ratio "1/1"
+         ;; :max-height "max(10rem, 30vh)"
+         :height "16rem"
+         }
    ["~ *" {;:margin-left "1rem"
            ;:margin-right "1rem"
            }]]


### PR DESCRIPTION
Just two small but important fixes for Safari/iOS devices where some of the images look oval and also an attempt to fix the picture of one of the speakers looking rotated on those devices as well (even though it doesn't with others and locally!?).