### PR TITLE
Update CNAME

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,1 @@
-www.reclojure.org
+reclojure.org


### PR DESCRIPTION
Removing the `www` so that the apex version of the website works well with https as well. Currently getting a name mismatch with https://reclojure.org/

![image](https://github.com/user-attachments/assets/0d4e4fb6-8647-40ad-9c4b-44c9f265f8e9)
